### PR TITLE
Add ability to customize the faraday logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you just want to interface with the API then the basic gem usage is below.
       wink.password = "**********"
       wink.endpoint = "https://winkapi.quirky.com"
       wink.wait_for_updates = true #this is the default setting is optional
+      wink.logger = Logger.new($stdout) #this is the default setting is optional
     end
 
     #retrieve the access_token and refresh_token

--- a/lib/winker.rb
+++ b/lib/winker.rb
@@ -36,10 +36,11 @@ module Winker
   end
   
   module Configuration
-    attr_accessor :client_id, :client_secret, :access_token, :refresh_token, :username, :password, :endpoint, :server_time_dif, :wait_for_updates
+    attr_accessor :client_id, :client_secret, :access_token, :refresh_token, :username, :password, :endpoint, :server_time_dif, :wait_for_updates, :logger
 
     def configure
       self.wait_for_updates = true
+      self.logger = Logger.new($stdout)
       yield self
     end
   end

--- a/lib/winker/connection.rb
+++ b/lib/winker/connection.rb
@@ -9,7 +9,7 @@ module Winker
         conn.response :json, :content_type => /\bjson$/
 
         conn.authorization :bearer, Winker.access_token if Winker.access_token
-        conn.response :detailed_logger
+        conn.response :detailed_logger, Winker.logger if Winker.logger
 
         conn.adapter Faraday.default_adapter # make requests with Net::HTTP
       end


### PR DESCRIPTION
I'm trying to use this gem in an simple Wink scheduling app I wrote, and I'd like to be able to customize the Faraday logging, which is pretty verbose.  I think this pull request leaves the current functionality in place by default but would allow users of this gem to override the defaults.
